### PR TITLE
Auth payload fix

### DIFF
--- a/src/ikev2.rs
+++ b/src/ikev2.rs
@@ -348,6 +348,8 @@ pub struct CertificateRequestPayload<'a> {
 #[derive(Debug, PartialEq)]
 pub struct AuthenticationPayload<'a> {
     pub auth_method: AuthenticationMethod,
+    pub reserved1: u8,
+    pub reserved2: u16,
     pub auth_data: &'a [u8],
 }
 

--- a/src/ikev2_parser.rs
+++ b/src/ikev2_parser.rs
@@ -217,9 +217,13 @@ pub fn parse_ikev2_payload_authentication(
         return Err(Err::Error(make_error(i, ErrorKind::Verify)));
     }
     let (i, auth_method) = map(be_u8, AuthenticationMethod)(i)?;
+    let (i, reserved1) = be_u8(i)?;
+    let (i, reserved2) = be_u16(i)?;
     let (i, auth_data) = take(length - 4)(i)?;
     let payload = AuthenticationPayload {
         auth_method,
+        reserved1,
+        reserved2,
         auth_data,
     };
     Ok((i, IkeV2PayloadContent::Authentication(payload)))


### PR DESCRIPTION
It looks like the Authentication payload was not properly handling the 3 reserved bytes. The Identification payload does this properly, so I modified `AuthenticationPayload` and `parse_ikev2_payload_authentication` to look like their Identification counterparts. 

You can see the two payload structures in the spec here: [Identification](https://datatracker.ietf.org/doc/html/rfc7296#section-3.5) and [Authentication](https://datatracker.ietf.org/doc/html/rfc7296#section-3.8) 